### PR TITLE
rename value to amount for clarity, add simple form error messages

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,16 +2,16 @@ import { Component } from '@angular/core';
 import { Transaction } from './transaction';
 
 const TRANSACTION_DATA: Transaction[] = [
-  {id: 1, description: 'Hydrogen', value: 1.0079, date: new Date().toLocaleDateString()},
-  {id: 2, description: 'Helium', value: 4.0026, date: new Date().toLocaleDateString()},
-  // {id: 3, description: 'Lithium', value: 6.941, date: new Date().toLocaleDateString()},
-  // {id: 4, description: 'Beryllium', value: 9.0122, date: new Date().toLocaleDateString()},
-  // {id: 5, description: 'Boron', value: 10.811, date: new Date().toLocaleDateString()},
-  // {id: 6, description: 'Carbon', value: 12.0107, date: new Date().toLocaleDateString()},
-  // {id: 7, description: 'Nitrogen', value: 14.0067, date: new Date().toLocaleDateString()},
-  // {id: 8, description: 'Oxygen', value: 15.9994, date: new Date().toLocaleDateString()},
-  // {id: 9, description: 'Fluorine', value: 18.9984, date: new Date().toLocaleDateString()},
-  // {id: 10, description: 'Neon', value: 20.1797, date: new Date().toLocaleDateString()},
+  {id: 1, description: 'Hydrogen', amount: 1.0079, date: new Date().toLocaleDateString()},
+  {id: 2, description: 'Helium', amount: 4.0026, date: new Date().toLocaleDateString()},
+  // {id: 3, description: 'Lithium', amount: 6.941, date: new Date().toLocaleDateString()},
+  // {id: 4, description: 'Beryllium', amount: 9.0122, date: new Date().toLocaleDateString()},
+  // {id: 5, description: 'Boron', amount: 10.811, date: new Date().toLocaleDateString()},
+  // {id: 6, description: 'Carbon', amount: 12.0107, date: new Date().toLocaleDateString()},
+  // {id: 7, description: 'Nitrogen', amount: 14.0067, date: new Date().toLocaleDateString()},
+  // {id: 8, description: 'Oxygen', amount: 15.9994, date: new Date().toLocaleDateString()},
+  // {id: 9, description: 'Fluorine', amount: 18.9984, date: new Date().toLocaleDateString()},
+  // {id: 10, description: 'Neon', amount: 20.1797, date: new Date().toLocaleDateString()},
 ];
 
 @Component({

--- a/src/app/quick-add/quick-add.component.html
+++ b/src/app/quick-add/quick-add.component.html
@@ -2,19 +2,23 @@
   <h3>quick add</h3>
   <form class="quick-add-form" [formGroup]="newTransaction" #form="ngForm" (ngSubmit)="onSubmit(form)" autocomplete="off">
     <mat-form-field>
-      <mat-label>Transaction value</mat-label>
-      <input matInput placeholder="Transaction value" value="" formControlName="value">
+      <mat-label>Transaction amount</mat-label>
+      <input matInput placeholder="Transaction amount" value="" formControlName="amount">
+      <span matPrefix>$&nbsp;</span>
+      <mat-error *ngIf="newTransaction.controls.amount.invalid">Required, must be valid amount*</mat-error>
     </mat-form-field>
 
     <mat-form-field>
       <mat-label>Transaction description</mat-label>
       <input matInput placeholder="Transaction description" value="" formControlName="description">
+      <mat-error *ngIf="newTransaction.controls.description.invalid">Required*</mat-error>
     </mat-form-field>
 
     <mat-form-field>
       <input matInput [matDatepicker]="transactionDatePick" placeholder="Transaction date" formControlName="date">
       <mat-datepicker-toggle matSuffix [for]="transactionDatePick"></mat-datepicker-toggle>
       <mat-datepicker #transactionDatePick></mat-datepicker>
+      <mat-error *ngIf="newTransaction.controls.date.invalid">Required, must be MM/DD/YYYY*</mat-error>
     </mat-form-field>
 
     <button mat-raised-button>add</button>

--- a/src/app/quick-add/quick-add.component.ts
+++ b/src/app/quick-add/quick-add.component.ts
@@ -21,7 +21,7 @@ export class QuickAddComponent implements OnInit {
 
   // Form controls
   newTransaction = new FormGroup({
-    value: new FormControl(null, {
+    amount: new FormControl(null, {
       validators: [
         Validators.required,
         Validators.pattern(/^-?\d+(\.?\d{1,2})?$/)
@@ -56,7 +56,7 @@ export class QuickAddComponent implements OnInit {
       const transaction = {
         // TODO: settle on transaction id convention
         id: 0,
-        value: this.newTransaction.value.value,
+        amount: this.newTransaction.value.amount,
         description: this.newTransaction.value.description,
         date: this.newTransaction.value.date.toLocaleDateString()
       };

--- a/src/app/transaction.ts
+++ b/src/app/transaction.ts
@@ -1,6 +1,6 @@
 export class Transaction {
   id?: number;
-  value: number;
+  amount: number;
   description: string;
   date: string;
 }


### PR DESCRIPTION
+ field for transaction "value" AKA "how much money it is" renamed to `amount` for clarity (eliminate `formGroup.value.value`)
+ add simple input-specific error messaging to form
+ prefix amount FKA value field with `$&nbsp;`